### PR TITLE
fix: make Sessions/Bottles/Breakthroughs visible in timeline queries

### DIFF
--- a/src/claude_memory/repository_queries.py
+++ b/src/claude_memory/repository_queries.py
@@ -36,12 +36,13 @@ class RepositoryQueryMixin:
         graph = self.select_graph()  # type: ignore[attr-defined]
         if project_id:
             query = """
-            MATCH (n:Entity)
+            MATCH (n)
             WHERE COALESCE(n.occurred_at, n.created_at) >= $start
               AND COALESCE(n.occurred_at, n.created_at) <= $end
               AND n.project_id = $project_id
+              AND n.node_type IS NOT NULL
             RETURN n
-            ORDER BY COALESCE(n.occurred_at, n.created_at) ASC
+            ORDER BY COALESCE(n.occurred_at, n.created_at) DESC
             LIMIT $limit
             """
             params = {
@@ -52,11 +53,12 @@ class RepositoryQueryMixin:
             }
         else:
             query = """
-            MATCH (n:Entity)
+            MATCH (n)
             WHERE COALESCE(n.occurred_at, n.created_at) >= $start
               AND COALESCE(n.occurred_at, n.created_at) <= $end
+              AND n.node_type IS NOT NULL
             RETURN n
-            ORDER BY COALESCE(n.occurred_at, n.created_at) ASC
+            ORDER BY COALESCE(n.occurred_at, n.created_at) DESC
             LIMIT $limit
             """
             params = {"start": start, "end": end, "limit": limit}

--- a/src/claude_memory/temporal.py
+++ b/src/claude_memory/temporal.py
@@ -35,8 +35,13 @@ class TemporalMixin:
         session_id = str(uuid.uuid4())
         timestamp = datetime.now(UTC).isoformat()
 
+        # Generate a session name from focus text for discoverability
+        focus_name = params.focus[:80].rstrip(".… ") if params.focus else ""
+        session_name = f"Session — {focus_name}" if focus_name else f"Session — {timestamp[:16]}"
+
         props = {
             "id": session_id,
+            "name": session_name,
             "project_id": params.project_id,
             "focus": params.focus,
             "status": "active",


### PR DESCRIPTION
## Summary

`query_timeline` uses `MATCH (n:Entity)` which only matches nodes with the `:Entity` graph label. Session, Bottle, and Breakthrough nodes have their own FalkorDB labels (`:Session`, `:Bottle`, `:Breakthrough`) and are completely invisible to timeline queries — including `reconnect`, which calls `query_timeline` internally.

This means a returning agent's reconnect briefing never shows recent sessions, bottles, or breakthroughs — only entities. For any Dragon Brain instance using the session/bottle workflow, this is a significant gap in temporal discoverability.

## Changes

**`repository_queries.py`:**
- `MATCH (n:Entity)` → `MATCH (n) WHERE n.node_type IS NOT NULL` (both branches)
- `ASC` → `DESC` sort order (newest first — what reconnect actually needs)
- `n.node_type IS NOT NULL` guard filters out bare observation nodes while including all typed entities

**`temporal.py`:**
- `start_session` now generates a `name` property from focus text: `"Session — {focus[:80]}"` with ISO timestamp fallback
- Previously sessions had no name, showing as \"(unnamed)\" in queries

## Context

We're running Dragon Brain for persistent memory across ~250 sessions. Discovered this when 5 sessions created by an autonomous loop were properly saved but invisible to `query_timeline` and `reconnect`. The sessions existed in the graph (reachable by ID via `get_neighbors`) but the `:Entity` label filter silently excluded them.

## Test plan

- [x] Verified `query_timeline` returns Session nodes after fix (tested via direct FalkorDB query)
- [x] Verified `reconnect` shows recent sessions in briefing
- [x] Verified new sessions get auto-generated names from focus text
- [ ] Existing tests should pass — label filter is not asserted in current test suite