### PR TITLE
fix: always hydrate observations in search results

### DIFF
--- a/src/claude_memory/search.py
+++ b/src/claude_memory/search.py
@@ -245,16 +245,17 @@ class SearchMixin(SearchAdvancedMixin):
                 if node_id in nodes_map:
                     node_props = nodes_map[node_id]
 
-                    # E-2: Deep hydration
-                    observations: list[str] = []
+                    # Observations are always hydrated — they are the entity's
+                    # own content and should never return as [].
+                    # Relationships are only included when deep=True.
+                    obs_query = (
+                        "MATCH (e {id: $eid})-[:HAS_OBSERVATION]->(o) "
+                        "RETURN o.content ORDER BY o.created_at ASC"
+                    )
+                    obs_res = self.repo.execute_cypher(obs_query, {"eid": node_id})
+                    observations: list[str] = [row[0] for row in obs_res.result_set if row[0]]
                     relationships: list[dict[str, str]] = []
                     if deep:
-                        obs_query = (
-                            "MATCH (e:Entity {id: $eid})-[:HAS_OBSERVATION]->(o) "
-                            "RETURN o.content ORDER BY o.created_at ASC"
-                        )
-                        obs_res = self.repo.execute_cypher(obs_query, {"eid": node_id})
-                        observations = [row[0] for row in obs_res.result_set if row[0]]
                         relationships = [
                             e
                             for e in graph_data["edges"]


### PR DESCRIPTION
## Summary

`search_memory` returns `observations: []` for every result unless `deep=True` is explicitly passed. Since observations are the entity's own content — the text an agent wrote about what they learned — this means every default search returns entities that appear empty even when they have rich content attached.

In practice, this forces agents into a two-step pattern: search → then `get_neighbors` on each result to see what's actually there. Most agents (including ours) frequently skip the second step and move on, assuming the entity has no content.

## Changes

**`search.py`:**
- Observation hydration query now runs unconditionally, not gated behind `deep` flag
- `MATCH (e:Entity {id: $eid})` → `MATCH (e {id: $eid})` so observations on Session, Bottle, and Breakthrough nodes also hydrate (same `:Entity` label issue as #7)
- Relationships remain gated behind `deep=True` — graph expansion is optional, observations are not

## Performance

One extra FalkorDB query per result (typically 10 per search). Each query is a single-hop traversal on an indexed ID. Negligible at any practical graph size.

## Context

We've been running Dragon Brain for persistent memory across ~250 sessions and ~1,240 observations. The `observations: []` trap has been the single biggest source of search unreliability — we built a PostToolUse hook to remind the agent to use `get_neighbors` after every search, which helped but didn't solve the root cause. This fix makes the default search return the full picture in one call.

## Test plan

- [x] Verified search results include observation content without `deep=True`
- [x] Verified observations on Session nodes (non-`:Entity` label) also hydrate
- [x] Verified relationships still require `deep=True`
- [ ] Existing tests should pass — observation content in results is additive