### PR TITLE
docs(v1.2.1): Round 2 audit remediation — release notes + docs + Auditor seat formalization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,7 +118,6 @@ gold_stack_run.log
 gauntlet_drift_check.log
 # Working artifacts (not part of the project)
 SPEC-*.md
-release_notes.md
 social_preview*.png
 graph.html
 test_dynamic_ontology.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.2.1] - 2026-05-17
+
+The output of **Round 2** of Dragon Brain's adversarial audit arc. ChatGPT Codex 5.5 was added as a formal Auditor seat in the AI Council trifecta workflow (Architect / Builder / Auditor / Director). Codex independently caught three production bugs that 10 batches of the previous trifecta had missed across Round 1. See `process/` for the full worked example.
+
+### Fixed
+
+- **Cypher label injection vulnerability** in `create_memory_type` — memory type names now validated against `[A-Z][A-Za-z0-9_]{0,63}` regex before interpolation into Cypher labels. Closes graph-corruption-from-typo hazard. (PR-1)
+- **`point_in_time_query` was producing wrong answers** — Qdrant payload didn't store `created_at`, so the temporal filter silently returned everything or nothing depending on query. Now stores `created_at` at write time; `scripts/backfill_created_at_payload.py` repairs existing points (live-safe, zero-downtime, idempotent). (PR-2)
+- **`get_temporal_neighbors` silently wrong on `direction="forward"`/`"backward"`** — schema accepted these spellings but repository only branched on `before`/`after`, so non-matching values silently fell through to the default `"both"` query. All four spellings now produce semantically correct results as permanent aliases (`forward`=`after`, `backward`=`before`). (PR-3)
+- **`add_observation` cross-store partial writes** — graph write succeeded but Qdrant failure left orphan Observation nodes. Now mirrors the `create_entity` compensation pattern: Qdrant failure triggers graph rollback via `DETACH DELETE` + raises `SearchError`. (PR-4)
+- **Channel degradation hidden from MCP callers** — per-channel health (`vector`, `fts`, `entity`, `temporal`, `relational`, `associative`) was computed during search but discarded. Now surfaced through `search_memory(include_meta=True).metadata.channels` so callers can detect partial-result conditions. (PR-5)
+- **TOCTOU risk in shared search metadata** — concurrent `search_memory` calls could cross-contaminate metadata via `self._last_*` shared instance attributes. Per-call return shape eliminates the shared state entirely. (PR-5)
+- **Contract scanner false positives** — Pattern 10 ("Sync IO in Async") flagged properly-awaited `AsyncMemoryRepository` calls because the heuristic didn't check the `await` keyword. Scanner now correctly recognizes awaited calls; absolute baseline returns to 13 (down from 75). (PR-6)
+
+### Changed
+
+- **`MemoryService.search()` return shape** — now returns `{"results": [...], "metadata": {...}}` dict at the service layer for both channel metadata exposure and per-call isolation. MCP boundary (`server.search_memory`) preserves backward compatibility: callers with default `include_meta=False` continue to receive a plain list. Only direct service-layer callers see the dict change.
+- **`MemoryService.search()` signature** — now accepts `params: SearchMemoryParams` (Pydantic-validated) instead of positional/keyword args. Internal callers updated; MCP boundary unchanged for downstream agents.
+- **Contract scanner baseline:** 75 → 13 (62 false positives eliminated via PR-6's await-detection fix).
+- **Unit test suite:** 1,166 → 1,278 tests, 0 failures.
+
+### Added
+
+- **`scripts/backfill_created_at_payload.py`** — live-safe, idempotent script to backfill `created_at` payload field for existing Qdrant points. <2 min runtime on ~2228 points, zero service stop.
+- **`process/` directory** — internal AI Council coordination artifacts (build spec, audit spec, per-PR handoff docs) organized under a clearly-labeled subdirectory. See [`process/README.md`](process/README.md) for context. Public-facing as a worked example of the trifecta pattern; library users don't need to read any of it.
+- **Test-first discipline framework** in internal specs — each PR requires a 5-row test design table (3 evil + 1 sad + 1 neutral) with explicit pre-PR/post-PR behavior. Auditor independently verifies "TEST FAILS" rows by re-running tests against the pre-PR base commit.
+- **Pre-handoff sanity checklist** in internal specs — 9-item deterministic gate AG runs before submitting any PR for audit (commit hash, mypy, contracts, ruff, bandit, caller sweep, etc.).
+
 ## [Unreleased]
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,9 +54,59 @@ If you hit `MEMORY_LAYER_DEGRADED`, the memory layer is broken — don't assume 
 - **Architecture:** `docs/ARCHITECTURE.md` (B9 deliverable) — trust boundary diagram + per-boundary contracts.
 - **Curriculum:** the patterns this audit applied — shape vs contract, behavioral contract tests, sub-batching discipline, tests-enforcing-bugs — are documented in operator's COMMANDNODE Code Literacy Layer 3.5. Not portable to public consumers; reference for operator-internal sessions only.
 
+## Audit Remediation Round 2 (May 13–17, 2026, v1.2.1)
+
+Round 1 (above) installed the SearchError contract and the `tox -e contracts` CI gate. Round 2 added an **adversarial Auditor seat** to the AI Council trifecta — ChatGPT Codex 5.5 — and proved its value end-to-end.
+
+### What the Auditor caught that Round 1 missed
+
+The previous trifecta (Claude as Architect + Antigravity as Builder) shipped 10 batches of remediation across April-May 2026. Codex's pre-build audit caught three production bugs the prior arc missed entirely:
+
+- **Cypher label injection** at `repository.py:90` — `MERGE (n:{label}:Entity ...)` interpolated unvalidated user input. Fixed in PR-1.
+- **Point-in-time `created_at` payload drift** — `search.py:187` filtered Qdrant on a field that `crud.py:136` never wrote. `point_in_time_query` was silently returning wrong answers. Fixed in PR-2.
+- **Temporal direction enum drift** — `schema.py:338` accepted `forward`/`backward` but `repository_queries.py:82` only matched `before`/`after`, silently routing unrecognized values to the default "both" branch. Fixed in PR-3.
+
+Plus three architectural improvements the audit drove:
+- Observation cross-store compensation symmetric with `create_entity` (PR-4)
+- Channel degradation observability through the MCP boundary (PR-5)
+- Contract scanner await-detection eliminating 62 false positives (PR-6)
+
+### The trifecta workflow (formalized)
+
+| Seat | Function |
+|------|----------|
+| **Director** | Strategy, final approval, calibration anchor |
+| **Architect** | Specs, audit guidelines, principles docs (this file, ARCHITECTURE.md, Code Literacy curriculum) |
+| **Builder** | Per-spec implementation. No editorial authority on principles documents |
+| **Auditor** | Adversarial verification per pre-defined criteria |
+
+**Audit-guidelines-before-build:** Auditor's criteria are written by the Architect *before* the Builder starts. The Auditor does not see the build recipe — outcomes, not recipes. Auditing the recipe biases verification toward checkbox-following instead of outcome-achievement.
+
+**Deterministic-tooling-as-fourth-leg:** LLM consensus ≠ correctness. The arc reaffirmed this — `scripts/trace_contracts_dragon.py` (AST contract scanner) caught 62 false-positive violations that LLM eyeballing could not have enumerated. Audit protocol now requires running deterministic tools BEFORE any LLM reasoning.
+
+### New API behavior (v1.2.1)
+
+User-facing changes from this arc:
+
+- `search_memory(include_meta=True)` now includes `metadata.channels` with per-channel health (`vector`, `fts`, `entity`, `temporal`, `relational`, `associative`). See "How to Search" → "Channel Health" below.
+- `get_temporal_neighbors(direction=...)` accepts all four spellings as permanent aliases: `before`=`backward`, `after`=`forward`, plus `both`. Previous silent-wrong-answer behavior is fixed.
+- `create_memory_type(name=...)` validates the name against `[A-Z][A-Za-z0-9_]{0,63}`. Invalid names raise `ValidationError` at the MCP boundary.
+- `point_in_time_query` now actually works as documented (was producing wrong answers pre-v1.2.1).
+- `add_observation` now compensates the graph write on Qdrant failure, matching `create_entity`'s pattern. No more graph-only orphan observations on infrastructure failure.
+
+### Where to dig deeper
+
+Full process artifacts public in [`process/`](process/):
+
+- [`process/REMEDIATION_BUILD_SPEC.md`](process/REMEDIATION_BUILD_SPEC.md) — builder-facing spec with per-PR concrete fix steps, test design tables, pre-handoff sanity checklist
+- [`process/REMEDIATION_AUDIT_SPEC.md`](process/REMEDIATION_AUDIT_SPEC.md) — auditor-facing spec with protocol, trigger semantics, scope rules
+- [`process/PR_1_HANDOFF.md`](process/PR_1_HANDOFF.md) through [`process/PR_6_HANDOFF.md`](process/PR_6_HANDOFF.md) — per-PR completion artifacts with tool outputs and per-criterion evidence
+
+The arc is documented as-shipped, including the 6-round PR-5 saga where the audit caught real defects (test bug masking the actual scenario, scope-creep refactor breaking dashboard/scripts callers, hash hygiene drift) before any could merge.
+
 ## What This Is
 
-A persistent memory system for AI agents. Knowledge graph (FalkorDB) + vector search (Qdrant) + MCP server. Any MCP-compatible client can store entities, observations, and relationships — then recall them semantically across sessions. Published on PyPI as `dragon-brain`. **v1.2.0 — 100% recall@5 on LongMemEval (ICLR 2025), no LLM required.**
+A persistent memory system for AI agents. Knowledge graph (FalkorDB) + vector search (Qdrant) + MCP server. Any MCP-compatible client can store entities, observations, and relationships — then recall them semantically across sessions. Published on PyPI as `dragon-brain`. **v1.2.1 — 100% recall@5 on LongMemEval (ICLR 2025), no LLM required.**
 
 ## Current Architecture
 
@@ -131,6 +181,30 @@ search_memory(query="recent work", include_meta=True)
 
 If the response includes `"temporal_exhausted": true`, widen the window for more history.
 
+### Channel Health (v1.2.1+)
+
+When you pass `include_meta=True`, the response also includes per-channel health for all 6 retrieval channels:
+
+```python
+result = search_memory(query="recent work", include_meta=True)
+# result["metadata"]["channels"] →
+# {
+#   "vector":      "healthy",
+#   "fts":         "failed",      # FTS DB unreachable
+#   "entity":      "healthy",
+#   "temporal":    "healthy",
+#   "relational":  "healthy",
+#   "associative": "degraded",
+# }
+```
+
+Channel statuses:
+- `"healthy"` — channel returned results normally
+- `"degraded"` — channel completed but with reduced quality (timeout fallback, partial result, etc.)
+- `"failed"` — channel infrastructure unavailable (FTS DB down, Qdrant unreachable, embedding service crashed, etc.)
+
+**Why it matters:** if FTS is down, your search returns only vector results — partial coverage that may miss keyword matches. The metadata tells you when to retry vs when to trust the result set. Pre-v1.2.1 this signal was computed internally but discarded before reaching callers (a shared-state TOCTOU bug also lurked there — fixed by per-call return shape).
+
 ### Understanding Results
 
 Each result includes:
@@ -156,6 +230,8 @@ create_entity(name="Project Alpha", node_type="Entity", project_id="my-project")
 ```
 
 Common node types: `Entity`, `Concept`, `Session`, `Breakthrough`, `Tool`, `Decision`, `Bottle`, `Analogy`, `Issue`, `Project`, `Procedure`, `Person`
+
+**Custom memory type name validation (v1.2.1+):** Custom types created via `create_memory_type(name=...)` are validated against `[A-Z][A-Za-z0-9_]{0,63}` — must start with an uppercase letter, alphanumeric + underscore only, max 64 chars. Invalid names raise `ValidationError` at the MCP boundary. Closes a Cypher injection / graph-corruption-from-typo vector (PR-1).
 
 ### Observations (Facts About Things)
 
@@ -249,6 +325,16 @@ Full results: [benchmarks/longmemeval/RESULTS.md](benchmarks/longmemeval/RESULTS
 | `diff_knowledge_state(as_of_start, as_of_end)` | "What changed between two dates?" — added/removed/evolved entities and relationships |
 | `start_session(project_id, focus)` | Begin a tracked session |
 | `end_session(session_id, summary)` | Close a session with outcomes |
+
+### Direction Aliases (v1.2.1+)
+
+`get_temporal_neighbors(direction=...)` accepts four spellings as permanent semantic equivalents:
+
+- `"before"` = `"backward"` — entities connected by incoming temporal edges (the past)
+- `"after"` = `"forward"` — entities connected by outgoing temporal edges (the future)
+- `"both"` — union (default)
+
+Pre-v1.2.1, only `before` / `after` / `both` produced correct results; `forward` / `backward` silently fell through to the default "both" branch — a silent wrong-answer bug fixed in PR-3. Both naming conventions now first-class.
 
 ### Time Diff
 

--- a/README.md
+++ b/README.md
@@ -399,6 +399,46 @@ Dragon Brain is the first open-source memory system we know of with a CI-enforce
 
 Full gauntlet results: [docs/GAUNTLET_RESULTS.md](docs/GAUNTLET_RESULTS.md) · Trust boundaries: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) · Integration tests: [tests/integration/test_db_kill_scenarios.py](tests/integration/test_db_kill_scenarios.py)
 
+### Round 2 (May 2026, v1.2.1) — The Adversarial Auditor
+
+Round 1 installed the contract that prevents silent failure. Round 2 added the auditor that catches the contract being violated.
+
+The AI Council formalized a four-seat trifecta:
+
+- **Architect** writes specs + audit criteria
+- **Builder** implements per spec
+- **Auditor** verifies per pre-defined criteria — independently of the builder
+- **Director** approves
+
+The auditor doesn't see the build recipe. Auditing recipes biases verification toward checkbox-following instead of outcome-achievement. The auditor sees the bug being fixed and the per-PR criteria; everything else they reconstruct from running the code themselves.
+
+**What the new auditor caught that 10 batches of prior Round 1 remediation missed:**
+
+- A **Cypher label injection** vector — unvalidated user input was being interpolated into a graph schema `MERGE` statement at `repository.py:90`
+- A **`point_in_time_query` silently returning wrong answers** — the temporal filter checked a Qdrant payload field that the writer never stored
+- A **temporal direction enum drift** — `forward`/`backward` parameter values silently fell through to the default branch because the repository only matched `before`/`after`
+
+Three real production bugs, in code that had already passed prior trifecta scrutiny. The auditor seat earned its keep on the first audit pass.
+
+**Plus a deterministic-tooling lesson reinforced:** the AST contract scanner caught 62 false-positive violations (properly-awaited async calls flagged because the scanner's heuristic didn't check the `await` keyword) that LLM eyeballing could never have enumerated. The audit protocol now mandates running deterministic tools (`tox -e contracts`, `mypy --strict`, `bandit`, `ruff`, `tox -e integration`) before any LLM reasoning. **LLM consensus ≠ correctness; deterministic tools are the fourth leg of the table.**
+
+**Full process artifacts public** in [`process/`](process/) as a worked example of the trifecta pattern in production:
+
+- [`process/REMEDIATION_BUILD_SPEC.md`](process/REMEDIATION_BUILD_SPEC.md) — builder-facing spec
+- [`process/REMEDIATION_AUDIT_SPEC.md`](process/REMEDIATION_AUDIT_SPEC.md) — auditor-facing spec
+- [`process/PR_1_HANDOFF.md`](process/PR_1_HANDOFF.md) through [`process/PR_6_HANDOFF.md`](process/PR_6_HANDOFF.md) — per-PR completion artifacts
+
+Includes the 6-round PR-5 saga where the auditor sent the builder back multiple times — for a test bug masking the actual scenario being tested, a scope-creep refactor that broke dashboard/scripts callers, and persistent handoff hygiene drift — before clean landing.
+
+### Updated Receipts (v1.2.1)
+
+- **1,278 unit tests** (up from 1,166) — 0 failures, integration tests passing under real-container `testcontainers` harness
+- **Contract scanner baseline: 13** (down from 75 — 62 false positives eliminated in PR-6's await-detection fix)
+- **Cross-store compensation symmetric** — both entity and observation create paths roll back graph writes on Qdrant failure
+- **Channel health observable** — `search_memory(include_meta=True).metadata.channels` exposes per-channel status (`healthy`/`degraded`/`failed`) across all 6 retrieval channels
+- **`point_in_time_query` actually works** — was producing wrong answers pre-v1.2.1; fixed via payload contract + backfill script
+- **Cypher injection vector closed** — `create_memory_type(name=...)` validates against a strict regex; defensive assert at the repository layer as belt-and-braces
+
 ## Why I Built This
 
 Claude is brilliant but forgets everything between conversations. Every new chat starts from scratch — no context, no continuity, no accumulated understanding. I wanted Claude to *remember* me: my projects, preferences, breakthroughs, and the connections between them. Not a flat chat history dump, but a living knowledge graph that grows richer over time.

--- a/docs/MCP_TOOL_REFERENCE.md
+++ b/docs/MCP_TOOL_REFERENCE.md
@@ -105,20 +105,46 @@ Add an observation (fact, note) linked to an entity.
 
 ### `search_memory`
 
-Search for entities using vector similarity. Supports strategy routing.
+Search for entities using vector similarity. Supports strategy routing and per-channel health metadata.
 
-| Param        | Type   | Default  |
-| ------------ | ------ | -------- |
-| `query`      | `str`  | required |
-| `project_id` | `str`  | `None`   |
-| `limit`      | `int`  | `10`     |
-| `offset`     | `int`  | `0`      |
-| `mmr`        | `bool` | `False`  |
-| `strategy`   | `str`  | `None`   |
+| Param                  | Type   | Default  | Description                                                       |
+| ---------------------- | ------ | -------- | ----------------------------------------------------------------- |
+| `query`                | `str`  | required | Search query                                                      |
+| `project_id`           | `str`  | `None`   | Scope to a single project                                         |
+| `limit`                | `int`  | `10`     | Max results                                                       |
+| `offset`               | `int`  | `0`      | Pagination offset                                                 |
+| `mmr`                  | `bool` | `False`  | Maximal Marginal Relevance reranking for result diversity         |
+| `strategy`             | `str`  | `None`   | Explicit channel routing — see below                              |
+| `temporal_window_days` | `int`  | `7`      | Lookback window for temporal queries                              |
+| `include_meta`         | `bool` | `False`  | Include `metadata` field with channel health + temporal exhaustion |
+| `deep`                 | `bool` | `False`  | Hydrate results with linked observations + relationships (E-2)    |
 
-**Strategy values:** `auto`, `semantic`, `associative`, `temporal`, `relational`
+**Strategy values:** `semantic`, `associative`, `temporal`, `relational`. Omit (default `None`) for hybrid search — vector + intent-detected graph enrichment, the recommended path. `strategy="auto"` is deprecated.
 
-**Returns:** `list[SearchResult]` — `{id, name, score, node_type, observations?, relationships?}`
+**Returns (default, `include_meta=False`):** `list[SearchResult]` — `{id, name, score, node_type, observations?, relationships?}`. Backward-compatible plain list shape for MCP callers.
+
+**Returns (`include_meta=True`):** `dict` —
+
+```python
+{
+    "results": list[SearchResult],
+    "metadata": {
+        "temporal_exhausted": bool,    # results may exist beyond temporal_window_days
+        "channels": {                  # per-channel health (v1.2.1+)
+            "vector":      "healthy" | "degraded" | "failed",
+            "fts":         "healthy" | "degraded" | "failed",
+            "entity":      "healthy" | "degraded" | "failed",
+            "temporal":    "healthy" | "degraded" | "failed",
+            "relational":  "healthy" | "degraded" | "failed",
+            "associative": "healthy" | "degraded" | "failed",
+        },
+    },
+}
+```
+
+> [!NOTE]
+> **v1.2.1:** Channel metadata is new. Pre-v1.2.1 only `temporal_exhausted` was surfaced.
+> Per-channel health was computed internally but discarded; a shared `_last_*` instance attribute also leaked metadata between concurrent calls (TOCTOU). Per-call dict return shape eliminates both.
 
 ### `search_associative`
 
@@ -215,7 +241,10 @@ Find entities connected by temporal edges.
 | `direction` | `str` | `"both"` |
 | `limit`     | `int` | `10`     |
 
-**Direction values:** `before`, `after`, `both`
+**Direction values:** `before` / `backward` (incoming temporal edges — the past), `after` / `forward` (outgoing temporal edges — the future), `both` (union, default).
+
+> [!NOTE]
+> **v1.2.1:** `forward` and `backward` are now permanent semantic aliases for `after` and `before`. Pre-v1.2.1, the schema accepted these spellings but the repository only branched on `before`/`after`, so `forward`/`backward` silently fell through to the default `both` query — a silent wrong-answer bug fixed in PR-3.
 
 **Returns:** `list[dict]` — temporal neighbors
 
@@ -247,6 +276,9 @@ Execute a search considering only knowledge known before `as_of`.
 | `as_of`      | `str` (ISO 8601) | required |
 
 **Returns:** `list[dict]` — results filtered by temporal cutoff
+
+> [!IMPORTANT]
+> **v1.2.1 bug fix:** This tool was producing wrong answers pre-v1.2.1. The Qdrant payload didn't store `created_at`, so the temporal filter at `vector_store.py` silently returned everything or nothing depending on query. Fixed in PR-2: payload now stores `created_at` at write time; `scripts/backfill_created_at_payload.py` repairs existing points (live-safe, zero-downtime, idempotent). If you operated a Dragon Brain instance pre-v1.2.1, run the backfill once after upgrade.
 
 ### `diff_knowledge_state`
 
@@ -431,6 +463,14 @@ Register a new memory type in the ontology.
 | `name`                | `str`       | required |
 | `description`         | `str`       | required |
 | `required_properties` | `list[str]` | `None`   |
+
+**Name validation (v1.2.1+):** `name` is validated against `[A-Z][A-Za-z0-9_]{0,63}` — must start with an uppercase letter, alphanumeric + underscore only, max 64 chars. Invalid names raise `ValidationError` at the MCP boundary.
+
+Examples accepted: `Entity`, `MemoryType`, `Concept_v2`, `A`.
+Examples rejected: `entity` (lowercase start), `Memory Type` (space), `Entity { x: 1}` (Cypher syntax), empty string.
+
+> [!IMPORTANT]
+> **v1.2.1 security fix:** Pre-v1.2.1, `name` was interpolated directly into a Cypher `MERGE (n:{name}:Entity ...)` query without validation. A malformed memory type name could corrupt the graph schema (Cypher injection / graph-corruption-from-typo). Fixed in PR-1: Pydantic validator at the MCP boundary as primary defense, defensive `assert` at the repository layer as belt-and-braces.
 
 **Returns:** `dict` — `{name, description, required_properties}`
 

--- a/docs/UPGRADE_LOG.md
+++ b/docs/UPGRADE_LOG.md
@@ -315,3 +315,80 @@ The system at Phase 3 completion had:
 | `sys.path.append` hack in dashboard      | **Removed** — package installed via pip     |
 | `app.py` monolithic `main()` (C901)      | **Extracted** 4 renderer functions          |
 | Globals undocumented in `tools_extra.py` | **Documented** with module-level docstrings |
+
+---
+
+## Audit Remediation Round 2 (May 13-17, 2026, v1.2.0 → v1.2.1)
+
+Codex 5.5 added as a formal **Auditor seat** in the AI Council trifecta. Codex independently caught three production bugs the prior trifecta (Architect + Builder only) missed across 10 batches of Round 1 remediation. Full process docs in `process/`.
+
+### PR-1: Cypher Label Injection Guard (`56f888d`)
+
+| Before                                                                       | After                                                                                          |
+| ---------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `MERGE (n:{label}:Entity ...)` interpolated unvalidated user input           | **Pydantic validator** on `CreateMemoryTypeParams.name` — regex `[A-Z][A-Za-z0-9_]{0,63}`      |
+| No defense-in-depth at repo layer                                            | **Defensive `assert`** on `label` in `repository.create_node` — catches future-bypass paths    |
+| Memory type names could corrupt graph schema silently                        | Invalid names raise `ValidationError` at MCP boundary; `AssertionError` at repo on direct call |
+
+### PR-2: Point-in-Time `created_at` Payload Contract (`1489886`)
+
+| Before                                                                | After                                                                                            |
+| --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `point_in_time_query` filtered Qdrant on `created_at` field           | **`created_at` written to payload** at all three sites (create_entity, add_observation, re-embed) |
+| Qdrant payload only had `name`, `node_type`, `project_id`             | Existing points repaired via `scripts/backfill_created_at_payload.py`                            |
+| Filter silently returned wrong answers (everything or empty)          | Live-safe, zero-downtime, idempotent backfill (~2228 points in <2 min)                           |
+
+### PR-3: Temporal Direction Enum Drift (`21b097a`)
+
+| Before                                                                | After                                                                                  |
+| --------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| Schema accepted `forward`/`backward`/`both`                           | Schema accepts `before`/`after`/`both`/`forward`/`backward` — all four spellings first-class |
+| Repo only branched on `before`/`after` — others fell through to "both" | Repo treats `before`=`backward` (past) and `after`=`forward` (future) as semantic equivalents |
+| `direction="forward"` was a silent wrong-answer bug                   | No DeprecationWarning, no churn — both naming conventions accepted permanently         |
+
+### PR-4: Observation Cross-Store Compensation (`e3a1ca8`)
+
+| Before                                                                | After                                                                                  |
+| --------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| `add_observation` graph-write success + Qdrant failure → orphan obs   | **Qdrant failure triggers graph `DETACH DELETE`** + raises `SearchError`               |
+| Asymmetric with `create_entity` (which DID compensate)                | Now symmetric — same pattern, same `SearchError` class, same log message format        |
+| Integration tests didn't exercise Qdrant-kill-mid-`add_observation`   | New `test_kill_qdrant_mid_add_observation_compensates` with real `container.kill()`    |
+
+### PR-5: Channel Degradation Surfaced Through MCP (`d1f2bd2` → `dd26413`)
+
+| Before                                                                | After                                                                                  |
+| --------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| Per-channel health computed but discarded                             | **`search_memory(include_meta=True).metadata.channels`** exposes all 6 channels        |
+| Shared `self._last_*` instance attrs (TOCTOU between concurrent calls) | **Per-call dict return shape** — no shared state, no crosstalk                         |
+| `MemoryService.search()` returned `list[SearchResult]`                | Service returns `dict` with `results` + `metadata`; MCP boundary strips when `include_meta=False` |
+| All internal callers used positional args                             | Service signature: `params: SearchMemoryParams` (Pydantic); ~10 internal sites updated |
+| 6 audit rounds to clear (caught real defects: test bug, scope creep, dashboard breakage) | Final clean landing with full test-first evidence + complete caller sweep              |
+
+### PR-6: Contract Scanner Precision (`e1e0318`)
+
+| Before                                                                | After                                                                                  |
+| --------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| Pattern 10 flagged `self.repo.X(...)` inside async def without checking `await` | **Await-detection** — `awaited_calls` set built from AST; awaited calls exempt from Pattern 10 |
+| 62 false positives from properly-migrated B10 wrapper calls           | Scanner reports actual baseline: **13 violations** (down from 75)                      |
+| CI gate silently failing since B10                                    | CI gate green at absolute baseline 13                                                  |
+| PR-4 also added `is_allowlisted(node)` honoring (out-of-spec scope creep, accepted) | Both mechanisms coexist: manual noqa markers + automatic await detection               |
+
+### Cumulative changes (Round 2)
+
+| Metric                      | Round 1 close (v1.2.0) | Round 2 close (v1.2.1) |
+| --------------------------- | ---------------------- | ---------------------- |
+| Unit tests                  | 1,166                  | 1,278                  |
+| Integration tests           | 5                      | 7 (added PIT + observation compensation) |
+| Contract scanner violations | 75 (with 62 FPs)       | 13 (true baseline)     |
+| MCP tools                   | 34                     | 34 (no new tools; behavior fixes) |
+| Process artifacts location  | root                   | `process/`             |
+| AI Council seats formalized | 3 (Architect/Builder/Director) | 4 (+ Auditor)  |
+
+### New scripts
+
+- `scripts/backfill_created_at_payload.py` — one-shot live-safe backfill for PR-2's Qdrant payload contract change
+
+### Files reorganized
+
+- `REMEDIATION_BUILD_SPEC.md`, `REMEDIATION_AUDIT_SPEC.md`, `PR_1_HANDOFF.md` through `PR_6_HANDOFF.md` moved from repo root into `process/`
+- New `process/README.md` explaining the directory and the AI Council trifecta workflow

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dragon-brain"
-version = "1.2.0"
+version = "1.2.1"
 description = "Open-source AI memory server — 100% on LongMemEval, knowledge graph + vector search, no LLM required"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,0 +1,44 @@
+## Dragon Brain v1.2.1 — Round 2 Audit Remediation
+
+This release closes the second adversarial audit arc, formalizing **ChatGPT Codex 5.5 as the Auditor seat** in the AI Council trifecta workflow (Architect / Builder / Auditor / Director). Codex independently caught three production bugs that 10 batches of the previous trifecta had missed — a Cypher label injection vector, a silently-broken `point_in_time_query`, and a temporal direction enum drift — all fixed in this release.
+
+### What's new for users
+
+- **`search_memory(include_meta=True)`** now exposes per-channel health metadata (`metadata.channels`) for all 6 retrieval channels (`vector`, `fts`, `entity`, `temporal`, `relational`, `associative`). Tells you when a result set is partial due to infrastructure degradation rather than genuine emptiness.
+- **`get_temporal_neighbors`** now accepts `forward`/`backward` as permanent aliases for `after`/`before` — both naming conventions first-class.
+- **`create_memory_type`** validates `name` against a strict regex; invalid names raise `ValidationError` at the MCP boundary.
+- **`point_in_time_query`** actually works now (was silently producing wrong answers pre-v1.2.1). If you've been running Dragon Brain, run `scripts/backfill_created_at_payload.py` once after upgrade to repair existing Qdrant points (live-safe, zero-downtime, <2 min on ~2228 points).
+
+### Backward compatibility
+
+MCP boundary preserved — callers using `search_memory` with the default `include_meta=False` continue to receive a plain list. Only direct `MemoryService.search()` callers see the new dict shape. No breaking changes for MCP consumers.
+
+### Full detail
+
+- [CHANGELOG.md § 1.2.1](CHANGELOG.md#121---2026-05-17) — per-PR breakdown
+- [README.md § Forged in Audit § Round 2](README.md#round-2-may-2026-v121--the-adversarial-auditor) — narrative
+- [`process/`](process/) — public worked-example artifacts (build spec, audit spec, per-PR handoff docs)
+
+---
+
+## Dragon Brain V2 — Initial Public Release
+
+Persistent memory for AI agents. A hybrid knowledge graph (FalkorDB) + vector search
+(Qdrant) MCP server that gives any MCP-compatible AI long-term memory across conversations.
+Works with Claude, Gemini CLI, Cursor, Windsurf, Cline, and more.
+
+### Highlights
+- 31 MCP tools for memory management
+- Hybrid semantic + graph search with Reciprocal Rank Fusion
+- Autonomous clustering agent ("The Librarian")
+- Time travel queries — explore your memory graph at any point in history
+- CUDA GPU support for embedding acceleration
+- 1,116 tests, mutation testing, property-based testing, fuzz testing
+- Dragon Brain Gauntlet: A- (95/100)
+
+### Quick Start
+```bash
+docker-compose up -d
+```
+
+See [README](https://github.com/iikarus/claude-memory-mcp#quick-start) for full setup.


### PR DESCRIPTION
## Dragon Brain v1.2.1 — Round 2 Audit Remediation

Closes the second adversarial audit arc. ChatGPT Codex 5.5 formally instated as the **Auditor seat** in the AI Council trifecta workflow after independently catching three production bugs the prior trifecta (Architect + Builder) missed across 10 batches of remediation.

### What ships in v1.2.1

- **3 production wrong-answer bug fixes:** Cypher label injection guard (PR-1), point-in-time `created_at` payload contract (PR-2), temporal direction enum drift (PR-3)
- **2 state-consistency closures:** observation cross-store compensation (PR-4), channel degradation surfaced through MCP (PR-5)
- **1 scanner precision fix:** contract scanner await-detection eliminating 62 false positives (PR-6)

### What's in this PR (docs only)

- `CHANGELOG.md` — full `[1.2.1]` entry
- `release_notes.md` — v1.2.1 highlights (now tracked; `.gitignore` updated)
- `CLAUDE.md` — Round 2 section + Channel Health, Direction Aliases, Memory Type Validation subsections
- `docs/MCP_TOOL_REFERENCE.md` — updated entries for `search_memory`, `get_temporal_neighbors`, `point_in_time_query`, `create_memory_type`
- `docs/UPGRADE_LOG.md` — Round 2 phase entry with per-PR before/after tables
- `README.md` — Round 2 subsection in Forged in Audit + updated Receipts
- `pyproject.toml` — version bump 1.2.0 → 1.2.1

### Full process artifacts

See [`process/`](process/) for the public worked-example: build spec, audit spec, all 6 per-PR handoff docs.

The PR-5 6-round saga (caught test bug, scope creep, dashboard breakage, hash hygiene drift before clean landing) is the kind of trifecta-in-production case study that doesn't usually become public.